### PR TITLE
changed hasHole so that it allows for certain non-manifold geometries…

### DIFF
--- a/src/SurfaceMesh.cpp
+++ b/src/SurfaceMesh.cpp
@@ -713,7 +713,7 @@ void flipNormals(SurfaceMesh &mesh) {
 bool hasHole(const SurfaceMesh &mesh) {
   for (auto eID : mesh.get_level_id<2>()) {
     auto cover = mesh.get_cover(eID);
-    if (cover.size() != 2) {
+    if (cover.size() < 2) {
       return true;
     }
   }


### PR DESCRIPTION
… (e.g. edge connected to three faces)

## Description
I want to generate a binary. Also I think this change is generally good because hasHole should only check for a hole, not general non-manifoldness. 

## Todos
 - Allows for some non-manifold geometries to be tetrahedralized (this is allowed on TetGen's side).

## Questions
- Does this break anything else? I don't think so. Couldn't find any other usages of hasHole().

## Status
- Ready to go