### PR TITLE
adding readPDB_distgrid to pygamer

### DIFF
--- a/pygamer/src/pygamer.cpp
+++ b/pygamer/src/pygamer.cpp
@@ -116,6 +116,21 @@ PYBIND11_MODULE(pygamer, pygamer) {
         )delim"
     );
 
+    pygamer.def("readPDB_distgrid", &readPDB_distgrid,
+        py::arg("filename"),
+        py::arg("radius") = 1.4,
+        R"delim(
+            Compute the Connolly surface using a distance grid based strategy
+
+            Args:
+                filename (:py:class:`str`): PDB file to read.
+                radius (:py:class:`float`): Radius in Angstroms of ball to roll over surface.
+            
+            Returns:
+                :py:class:`surfacemesh.SurfaceMesh`: Meshed object.
+        )delim"
+    );
+    
     pygamer.def("readPDB_gauss", &readPDB_gauss,
         py::arg("filename"),
         py::arg("blobbyness") = -0.2,


### PR DESCRIPTION
## Description
Add `readPDB_distgrid` to pygamer

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] readPDB_distgrid available and functional

## Questions
- [ ] Are there any other files that need to be changed/updated?
- [ ] Additional testing? Everything compiled and worked on my Mac with Python 3.10 (`macosx-13.0-arm64-3.10`)

## Status
- [ ] Ready to go